### PR TITLE
string> was added in emacs jun 2015.

### DIFF
--- a/color-moccur.el
+++ b/color-moccur.el
@@ -860,8 +860,13 @@ automatic display of the corresponding source code location."
 (defvar moccur-grep-search-file-pos nil)
 
 ;;; For All Emacs
-(defmacro string> (a b) (list 'not (list 'or (list 'string= a b)
-                                         (list 'string< a b))))
+
+(if (version< emacs-version "25.1")
+    (defmacro string> (a b) 
+      (list 'not (list 'or (list 'string= a b)
+		       (list 'string< a b)))))
+
+
 (autoload 'migemo-get-pattern "migemo" "migemo-get-pattern" nil)
 
 ;;; For xemacs


### PR DESCRIPTION
So it's probably in 25.1 released in 2016