### PR TITLE
Only define string> if it isn't already defined.

### DIFF
--- a/color-moccur.el
+++ b/color-moccur.el
@@ -860,8 +860,9 @@ automatic display of the corresponding source code location."
 (defvar moccur-grep-search-file-pos nil)
 
 ;;; For All Emacs
-(defmacro string> (a b) (list 'not (list 'or (list 'string= a b)
-                                         (list 'string< a b))))
+(unless (functionp 'string>)
+  (defmacro string> (a b) (list 'not (list 'or (list 'string= a b)
+                                       (list 'string< a b)))))
 (autoload 'migemo-get-pattern "migemo" "migemo-get-pattern" nil)
 
 ;;; For xemacs


### PR DESCRIPTION
Fixes #8